### PR TITLE
Fixes entrega1

### DIFF
--- a/.tern-project
+++ b/.tern-project
@@ -1,0 +1,1 @@
+{"ide":{},"libs":["ecma5","browser"],"plugins":{"guess-types":{},"outline":{},"angular":{}}}

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/RouteProvider.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/RouteProvider.java
@@ -36,7 +36,7 @@ public class RouteProvider {
 	private CharacterGroupDAO groupsRepo = CharacterGroupTestRepository.getInstance();
 	private UsersController userController = new UsersController(userRepo, characRepo);
 	private MarvelCharactersController characterController = new MarvelCharactersController(characRepo);
-	private CharacterGroupsControllers groupsController = new CharacterGroupsControllers(groupsRepo, characRepo);
+	private CharacterGroupsController groupsController = new CharacterGroupsController(groupsRepo, characRepo);
 	private ReportsController reportsController = new ReportsController();
 	@GET
 	@Path("/users")
@@ -316,19 +316,6 @@ public class RouteProvider {
 			return Response.status(Status.NOT_FOUND).build();
 		} catch (DuplicateTacsModelException e) {
 			return Response.status(Status.CONFLICT).build();
-		}
-	}
-
-	@DELETE
-	@Path("/groups/{id}/characters")
-	public Response deleteGroupCharacters(@PathParam("id") String rawId) {
-		try {
-			groupsController.removeCharacters(rawId);
-			return Response.ok().build();
-		} catch (InvalidTacsModelException e) {
-			return Response.status(Status.BAD_REQUEST).build();
-		} catch (InexistentTacsModelException e) {
-			return Response.status(Status.NOT_FOUND).build();
 		}
 	}
 

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/RouteProvider.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/RouteProvider.java
@@ -19,6 +19,7 @@ import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
 import com.utn.tacs.tacsthree.models.CharacterGroup;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.models.TacsModel;
 import com.utn.tacs.tacsthree.models.User;
 import com.utn.tacs.tacsthree.persistence.CharacterGroupDAO;
 import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
@@ -36,7 +37,7 @@ public class RouteProvider {
 	private UsersController userController = new UsersController(userRepo, characRepo);
 	private MarvelCharactersController characterController = new MarvelCharactersController(characRepo);
 	private CharacterGroupsControllers groupsController = new CharacterGroupsControllers(groupsRepo, characRepo);
-
+	private ReportsController reportsController = new ReportsController();
 	@GET
 	@Path("/users")
 	@Produces("application/json")
@@ -129,9 +130,9 @@ public class RouteProvider {
 	@GET
 	@Path("/users/{id}/characters")
 	@Produces("application/json")
-	public Response getUserFavorites(@PathParam("id") String rawId) {
+	public Response getUserCharacters(@PathParam("id") String rawId) {
 		try {
-			return Response.ok(userController.getFavoritesOf(rawId)).build();
+			return Response.ok(userController.getCharactersOf(rawId)).build();
 		} catch (InexistentTacsModelException e) {
 			return Response.status(Status.NOT_FOUND).build();
 		}
@@ -142,9 +143,9 @@ public class RouteProvider {
 	@Path("/users/{id}/characters")
 	@Produces("application/json")
 	@Consumes("application/json")
-	public Response addUserFavorite(@PathParam("id") String rawId, MarvelCharacter charac) {
+	public Response addUserCharacter(@PathParam("id") String rawId, MarvelCharacter charac) {
 		try {
-			return Response.ok(userController.addFavorite(rawId, charac)).build();
+			return Response.ok(userController.addCharacter(rawId, charac)).build();
 		} catch (InvalidTacsModelException e) {
 			return Response.status(Status.BAD_REQUEST).build();
 		} catch (InexistentTacsModelException e) {
@@ -156,9 +157,9 @@ public class RouteProvider {
 
 	@DELETE
 	@Path("/users/{id}/characters")
-	public Response deleteUserFavorites(@PathParam("id") String rawId) {
+	public Response deleteUserCharacter(@PathParam("id") String rawId) {
 		try {
-			userController.removeFavorites(rawId);
+			userController.removeCharactersOf(rawId);
 			return Response.ok().build();
 		} catch (InexistentTacsModelException e) {
 			return Response.status(Status.NOT_FOUND).build();
@@ -169,9 +170,9 @@ public class RouteProvider {
 
 	@DELETE
 	@Path("/users/{id}/characters/{id2}")
-	public Response deleteUserSingleFavorite(@PathParam("id") String usrId, @PathParam("id2") String characId) {
+	public Response deleteUserSingleCharacter(@PathParam("id") String usrId, @PathParam("id2") String characId) {
 		try {
-			userController.removeFavorite(usrId, characId);
+			userController.removeCharacter(usrId, characId);
 			return Response.ok().build();
 		} catch (InexistentTacsModelException e) {
 			return Response.status(Status.NOT_FOUND).build();
@@ -306,7 +307,7 @@ public class RouteProvider {
 	@Path("/groups/{id}/characters")
 	@Produces("application/json")
 	@Consumes("application/json")
-	public Response addCharacter(@PathParam("id") String chId, MarvelCharacter character) {
+	public Response addCharacter(@PathParam("id") String chId, TacsModel character) {
 		try {
 			return Response.ok(groupsController.addCharacter(chId, character)).build();
 		} catch (InvalidTacsModelException e) {
@@ -342,5 +343,11 @@ public class RouteProvider {
 		} catch (InexistentTacsModelException e) {
 			return Response.status(Status.NOT_FOUND).build();
 		}
+	}
+	
+	@GET
+	@Path("/reports")
+	public Response getReports() {
+		return Response.ok(reportsController.getReports()).build();		
 	}
 }

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/RouteProvider.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/RouteProvider.java
@@ -38,6 +38,7 @@ public class RouteProvider {
 	private MarvelCharactersController characterController = new MarvelCharactersController(characRepo);
 	private CharacterGroupsController groupsController = new CharacterGroupsController(groupsRepo, characRepo);
 	private ReportsController reportsController = new ReportsController();
+
 	@GET
 	@Path("/users")
 	@Produces("application/json")
@@ -331,10 +332,15 @@ public class RouteProvider {
 			return Response.status(Status.NOT_FOUND).build();
 		}
 	}
-	
+
 	@GET
 	@Path("/reports")
+	@Produces("application/json")
 	public Response getReports() {
-		return Response.ok(reportsController.getReports()).build();		
+		try {
+			return Response.ok(reportsController.getReports()).build();
+		} catch (NullPointerException e) {
+			return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+		}
 	}
 }

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/CharacterGroupsController.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/CharacterGroupsController.java
@@ -1,7 +1,6 @@
 package com.utn.tacs.tacsthree.api.v1.controllers;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import com.utn.tacs.tacsthree.exceptions.DuplicateTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
@@ -9,16 +8,15 @@ import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
 import com.utn.tacs.tacsthree.models.CharacterGroup;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
 import com.utn.tacs.tacsthree.models.TacsModel;
-import com.utn.tacs.tacsthree.models.User;
 import com.utn.tacs.tacsthree.persistence.CharacterGroupDAO;
 import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
 
-public class CharacterGroupsControllers {
+public class CharacterGroupsController {
 
 	private CharacterGroupDAO repository;
 	private MarvelCharacterDAO characterRepo;
 
-	public CharacterGroupsControllers(CharacterGroupDAO _repository, MarvelCharacterDAO _characterRepo) {
+	public CharacterGroupsController(CharacterGroupDAO _repository, MarvelCharacterDAO _characterRepo) {
 		this.repository = _repository;
 		this.characterRepo = _characterRepo;
 	}
@@ -86,12 +84,6 @@ public class CharacterGroupsControllers {
 		} catch (InexistentTacsModelException e) {
 			throw new InvalidTacsModelException("character doesn't exist");
 		}
-	}
-
-	public void removeCharacters(String _id) throws InexistentTacsModelException, InvalidTacsModelException {
-		CharacterGroup group = getGroup(_id);
-		group.removeAllCharacters();
-		updateGroup(group);
 	}
 
 	public void removeCharacter(String _groupId, String _characterId)

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/CharacterGroupsControllers.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/CharacterGroupsControllers.java
@@ -8,6 +8,8 @@ import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
 import com.utn.tacs.tacsthree.models.CharacterGroup;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.models.TacsModel;
+import com.utn.tacs.tacsthree.models.User;
 import com.utn.tacs.tacsthree.persistence.CharacterGroupDAO;
 import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
 
@@ -68,19 +70,21 @@ public class CharacterGroupsControllers {
 		return getGroup(_id).getCharacters();
 	}
 
-	public CharacterGroup addCharacter(String _id, MarvelCharacter _character)
+	public CharacterGroup addCharacter(String _id, TacsModel _character)
 			throws InexistentTacsModelException, InvalidTacsModelException, DuplicateTacsModelException {
 		CharacterGroup group = getGroup(_id);
 		MarvelCharacter obtainedCharacter = null;
 		try {
 			obtainedCharacter = characterRepo.get(_character);
-			group.getCharacter(_character);
-			throw new DuplicateTacsModelException("character already in group");
+			try {
+				group.getCharacter(_character);
+				throw new DuplicateTacsModelException("character already in group");
+			} catch (InexistentTacsModelException e) {
+				group.addCharacters(obtainedCharacter);
+				return updateGroup(group);
+			}
 		} catch (InexistentTacsModelException e) {
 			throw new InvalidTacsModelException("character doesn't exist");
-		} catch (NoSuchElementException e) {
-			group.addCharacters(obtainedCharacter);
-			return updateGroup(group);
 		}
 	}
 
@@ -93,7 +97,7 @@ public class CharacterGroupsControllers {
 	public void removeCharacter(String _groupId, String _characterId)
 			throws InexistentTacsModelException, InvalidTacsModelException {
 		CharacterGroup group = getGroup(_groupId);
-		MarvelCharacter character = characterRepo.get(new MarvelCharacter(_characterId));
+		TacsModel character = characterRepo.get(new MarvelCharacter(_characterId));
 		group.removeCharacters(character);
 		updateGroup(group);
 	}

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/MarvelCharactersController.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/MarvelCharactersController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.models.TacsModel;
 import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
 
 public class MarvelCharactersController {
@@ -17,7 +18,7 @@ public class MarvelCharactersController {
 		return repository.get();
 	}
 
-	public MarvelCharacter getCharacter(String _id) throws InexistentTacsModelException {
+	public TacsModel getCharacter(String _id) throws InexistentTacsModelException {
 		return repository.get(new MarvelCharacter(_id));
 	}
 

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/ReportsController.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/ReportsController.java
@@ -1,9 +1,21 @@
 package com.utn.tacs.tacsthree.api.v1.controllers;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.utn.tacs.tacsthree.models.Report;
+import com.utn.tacs.tacsthree.models.ReportFavoriteCharacterRanking;
+
 public class ReportsController {
 
-	public Object getReports() {
-		return "Hey hey hey!";
+	private List<Report> reports = new ArrayList<Report>();
+
+	public ReportsController() {
+		reports.add(new ReportFavoriteCharacterRanking());
+	}
+
+	public List<Report> getReports() {
+		return reports;
 	}
 
 }

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/ReportsController.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/ReportsController.java
@@ -1,0 +1,9 @@
+package com.utn.tacs.tacsthree.api.v1.controllers;
+
+public class ReportsController {
+
+	public Object getReports() {
+		return "Hey hey hey!";
+	}
+
+}

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/UsersController.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/UsersController.java
@@ -7,6 +7,7 @@ import com.utn.tacs.tacsthree.exceptions.DuplicateTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.models.TacsModel;
 import com.utn.tacs.tacsthree.models.User;
 import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
 import com.utn.tacs.tacsthree.persistence.UserDAO;
@@ -61,37 +62,39 @@ public class UsersController {
 
 	// Favorite Characters
 
-	public List<MarvelCharacter> getFavoritesOf(String _id) throws InexistentTacsModelException {
-		return getUser(_id).getFavorites();
+	public List<MarvelCharacter> getCharactersOf(String _id) throws InexistentTacsModelException {
+		return getUser(_id).getCharacters();
 	}
 
-	public User addFavorite(String _id, MarvelCharacter _character)
+	public User addCharacter(String _id, MarvelCharacter _character)
 			throws InexistentTacsModelException, InvalidTacsModelException, DuplicateTacsModelException {
 		User user = getUser(_id);
 		MarvelCharacter obtainedCharacter = null;
 		try {
 			obtainedCharacter = characterRepository.get(_character);
-			user.getFavorite(_character);
-			throw new DuplicateTacsModelException("character already favorite");
+			try {
+				user.getCharacter(_character);
+				throw new DuplicateTacsModelException("character already favorite");
+			} catch (InexistentTacsModelException e) {
+				user.addCharacter(obtainedCharacter);
+				return updateUser(user);
+			}
 		} catch (InexistentTacsModelException e) {
 			throw new InvalidTacsModelException("character doesn't exist");
-		} catch (NoSuchElementException e) {
-			user.addFavorite(obtainedCharacter);
-			return updateUser(user);
 		}
 	}
 
-	public void removeFavorites(String _id) throws InexistentTacsModelException, InvalidTacsModelException {
+	public void removeCharactersOf(String _id) throws InexistentTacsModelException, InvalidTacsModelException {
 		User user = getUser(_id);
-		user.removeFavorites();
+		user.removeCharacters();
 		updateUser(user);
 	}
 
-	public void removeFavorite(String userId, String favId)
+	public void removeCharacter(String userId, String favId)
 			throws InexistentTacsModelException, InvalidTacsModelException {
 		User user = getUser(userId);
-		MarvelCharacter fav = characterRepository.get(new MarvelCharacter(favId));
-		user.removeFavorite(fav);
+		TacsModel fav = characterRepository.get(new MarvelCharacter(favId));
+		user.removeCharacter(fav);
 		updateUser(user);
 	}
 }

--- a/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/UsersController.java
+++ b/src/main/java/com/utn/tacs/tacsthree/api/v1/controllers/UsersController.java
@@ -1,8 +1,6 @@
 package com.utn.tacs.tacsthree.api.v1.controllers;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-
 import com.utn.tacs.tacsthree.exceptions.DuplicateTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;

--- a/src/main/java/com/utn/tacs/tacsthree/models/CharacterGroup.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/CharacterGroup.java
@@ -34,7 +34,7 @@ public class CharacterGroup extends TacsModel {
 		this.characters.add(_charact);
 	}
 
-	public Boolean removeCharacters(MarvelCharacter _charact) {
+	public Boolean removeCharacters(TacsModel _charact) {
 		return this.characters.remove(_charact);
 	}
 
@@ -52,7 +52,7 @@ public class CharacterGroup extends TacsModel {
 			throw new InvalidTacsModelException("invalid characters");
 	}
 
-	public MarvelCharacter getCharacter(MarvelCharacter _character) {
+	public TacsModel getCharacter(TacsModel _character) {
 		return getCharacters().stream().filter(u -> u.getId().equals(_character.getId())).findFirst().get();
 	}
 

--- a/src/main/java/com/utn/tacs/tacsthree/models/CharacterGroup.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/CharacterGroup.java
@@ -2,6 +2,8 @@ package com.utn.tacs.tacsthree.models;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
 import org.mongodb.morphia.annotations.Entity;
 
@@ -34,12 +36,15 @@ public class CharacterGroup extends TacsModel {
 		this.characters.add(_charact);
 	}
 
-	public Boolean removeCharacters(TacsModel _charact) {
-		return this.characters.remove(_charact);
+	public MarvelCharacter getCharacter(TacsModel _character) throws InexistentTacsModelException {
+		for (MarvelCharacter character : getCharacters())
+			if (character.sameModels(_character))
+				return character;
+		throw new InexistentTacsModelException("character is not in group");
 	}
 
-	public void removeAllCharacters() {
-		this.characters.clear();
+	public Boolean removeCharacters(TacsModel _charact) {
+		return this.characters.remove(_charact);
 	}
 
 	@Override
@@ -50,10 +55,6 @@ public class CharacterGroup extends TacsModel {
 			throw new InvalidTacsModelException("invalid name");
 		if (this.getCharacters().isEmpty())
 			throw new InvalidTacsModelException("invalid characters");
-	}
-
-	public TacsModel getCharacter(TacsModel _character) {
-		return getCharacters().stream().filter(u -> u.getId().equals(_character.getId())).findFirst().get();
 	}
 
 }

--- a/src/main/java/com/utn/tacs/tacsthree/models/MarvelCharacter.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/MarvelCharacter.java
@@ -136,5 +136,4 @@ public class MarvelCharacter extends TacsModel {
 		if (this.getId() == null)
 			throw new InvalidTacsModelException("invalid id");
 	}
-
 }

--- a/src/main/java/com/utn/tacs/tacsthree/models/Report.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/Report.java
@@ -1,0 +1,31 @@
+package com.utn.tacs.tacsthree.models;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
+
+public abstract class Report extends TacsModel {
+
+	@JsonProperty("name")
+	private String name;
+
+	private String getName() {
+		return name;
+	}
+
+	public void setName(String _name) {
+		this.name = _name;
+	}
+
+	@JsonProperty("data")
+	public abstract String getData();
+
+	@Override
+	public void valid() throws InvalidTacsModelException {
+		if (this.getId() == null)
+			throw new InvalidTacsModelException("invalid id");
+		if (this.getName() == null)
+			throw new InvalidTacsModelException("invalid name");
+	}
+
+}

--- a/src/main/java/com/utn/tacs/tacsthree/models/ReportFavoriteCharacterRanking.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/ReportFavoriteCharacterRanking.java
@@ -1,0 +1,17 @@
+package com.utn.tacs.tacsthree.models;
+
+import org.codehaus.jackson.annotate.JsonRawValue;
+
+public class ReportFavoriteCharacterRanking extends Report {
+
+	public ReportFavoriteCharacterRanking() {
+		super.setName("Ranking de Personajes favoritos");
+	}
+	
+	@Override
+	@JsonRawValue
+	public String getData() {
+		return "{\"holis\":\"holis\"}";
+	}
+
+}

--- a/src/main/java/com/utn/tacs/tacsthree/models/TacsModel.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/TacsModel.java
@@ -20,4 +20,8 @@ public abstract class TacsModel {
 	}
 
 	public abstract void valid() throws InvalidTacsModelException;
+
+	public Boolean sameModels(TacsModel _model) {
+		return getId().equals(_model.getId());
+	}
 }

--- a/src/main/java/com/utn/tacs/tacsthree/models/User.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/User.java
@@ -2,8 +2,8 @@ package com.utn.tacs.tacsthree.models;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
+import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
 
 import org.mongodb.morphia.annotations.Entity;
@@ -12,7 +12,7 @@ import org.mongodb.morphia.annotations.Entity;
 public class User extends TacsModel {
 
 	private String name = null;
-	private List<MarvelCharacter> favoriteCharacters = new ArrayList<MarvelCharacter>();
+	private List<MarvelCharacter> characters = new ArrayList<MarvelCharacter>();
 
 	public User() {
 	}
@@ -34,24 +34,28 @@ public class User extends TacsModel {
 		this.name = name;
 	}
 
-	public List<MarvelCharacter> getFavorites() {
-		return favoriteCharacters;
+	public List<MarvelCharacter> getCharacters() {
+		return characters;
 	}
 
-	public void addFavorite(MarvelCharacter _charact) {
-		this.favoriteCharacters.add(_charact);
+	public void addCharacter(MarvelCharacter _charact) {
+		this.characters.add(_charact);
 	}
 
-	public Boolean removeFavorite(MarvelCharacter _charact) {
-		return this.favoriteCharacters.remove(_charact);
+	public Boolean removeCharacter(TacsModel _charact) {
+		return this.characters.remove(_charact);
 	}
 
-	public void removeFavorites() {
-		this.favoriteCharacters.clear();
+	public void removeCharacters() {
+		this.characters.clear();
 	}
 
-	public MarvelCharacter getFavorite(MarvelCharacter _charact) throws NoSuchElementException {
-		return getFavorites().stream().filter(u -> u.getId().equals(_charact.getId())).findFirst().get();
+	public TacsModel getCharacter(TacsModel _charact) throws InexistentTacsModelException {
+		for (TacsModel character : getCharacters()) {
+			if (character.getId().equals(_charact.getId()))
+				return character;
+		}
+		throw new InexistentTacsModelException("character is not favorite of user: " + getName());
 	}
 
 	@Override
@@ -60,7 +64,7 @@ public class User extends TacsModel {
 			throw new InvalidTacsModelException("invalid id");
 		if (this.getName() == null)
 			throw new InvalidTacsModelException("invalid name");
-		if (this.getFavorites() == null)
+		if (this.getCharacters() == null)
 			throw new InvalidTacsModelException("invalid favorites");
 	}
 }

--- a/src/main/java/com/utn/tacs/tacsthree/models/User.java
+++ b/src/main/java/com/utn/tacs/tacsthree/models/User.java
@@ -13,6 +13,7 @@ public class User extends TacsModel {
 
 	private String name = null;
 	private List<MarvelCharacter> characters = new ArrayList<MarvelCharacter>();
+	private List<CharacterGroup> groups = new ArrayList<CharacterGroup>();
 
 	public User() {
 	}
@@ -50,6 +51,30 @@ public class User extends TacsModel {
 		this.characters.clear();
 	}
 
+	public List<CharacterGroup> getGroups() {
+		return groups;
+	}
+
+	public CharacterGroup getGroup(CharacterGroup _group) throws InexistentTacsModelException {
+		for (CharacterGroup group : getGroups()) {
+			if (group.getId().equals(_group.getId()))
+				return group;
+		}
+		throw new InexistentTacsModelException("group was not created by user: " + getName());
+	}
+
+	public void addGroup(CharacterGroup _group) {
+		this.groups.add(_group);
+	}
+
+	public Boolean removeGroup(CharacterGroup _group) {
+		return this.groups.remove(_group);
+	}
+
+	public void removeGroup() {
+		this.groups.clear();
+	}
+
 	public TacsModel getCharacter(TacsModel _charact) throws InexistentTacsModelException {
 		for (TacsModel character : getCharacters()) {
 			if (character.getId().equals(_charact.getId()))
@@ -65,6 +90,8 @@ public class User extends TacsModel {
 		if (this.getName() == null)
 			throw new InvalidTacsModelException("invalid name");
 		if (this.getCharacters() == null)
-			throw new InvalidTacsModelException("invalid favorites");
+			throw new InvalidTacsModelException("invalid favorite list");
+		if (this.getGroups() == null)
+			throw new InvalidTacsModelException("invalid group list");
 	}
 }

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/MarvelCharacterDAO.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/MarvelCharacterDAO.java
@@ -4,10 +4,11 @@ import java.util.List;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.models.TacsModel;
 
 public interface MarvelCharacterDAO {
 
 	List<MarvelCharacter> get();
 
-	MarvelCharacter get(MarvelCharacter _character) throws InexistentTacsModelException;
+	MarvelCharacter get(TacsModel _character) throws InexistentTacsModelException;
 }

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/CharacterGroupTestRepository.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/CharacterGroupTestRepository.java
@@ -16,20 +16,22 @@ public class CharacterGroupTestRepository implements CharacterGroupDAO {
 		return instance;
 	}
 
-	private List<CharacterGroup> groupList = new ArrayList<CharacterGroup>();
+	public List<CharacterGroup> groupList = new ArrayList<CharacterGroup>();
 
 	public void restart() {
 		groupList.clear();
-	}
-
-	public CharacterGroupTestRepository() {
-		restart();
+		Integer index = 0;
 		for (MarvelCharacter _charac : MarvelCharacterTestRepository.getInstance().get()) {
 			CharacterGroup group = new CharacterGroup();
+			group.setId((index++).toString() + "709b8799a96331925075510");
 			group.setName("Group of " + _charac.getName());
 			group.addCharacters(_charac);
 			groupList.add(group);
 		}
+	}
+
+	public CharacterGroupTestRepository() {
+		restart();
 	}
 
 	@Override

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/CharacterGroupTestRepository.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/CharacterGroupTestRepository.java
@@ -2,10 +2,10 @@ package com.utn.tacs.tacsthree.persistence.mocks;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.models.CharacterGroup;
+import com.utn.tacs.tacsthree.models.MarvelCharacter;
 import com.utn.tacs.tacsthree.persistence.CharacterGroupDAO;
 
 public class CharacterGroupTestRepository implements CharacterGroupDAO {
@@ -24,6 +24,12 @@ public class CharacterGroupTestRepository implements CharacterGroupDAO {
 
 	public CharacterGroupTestRepository() {
 		restart();
+		for (MarvelCharacter _charac : MarvelCharacterTestRepository.getInstance().get()) {
+			CharacterGroup group = new CharacterGroup();
+			group.setName("Group of " + _charac.getName());
+			group.addCharacters(_charac);
+			groupList.add(group);
+		}
 	}
 
 	@Override
@@ -33,11 +39,10 @@ public class CharacterGroupTestRepository implements CharacterGroupDAO {
 
 	@Override
 	public CharacterGroup get(CharacterGroup group) throws InexistentTacsModelException {
-		try {
-			return groupList.stream().filter(o -> o.getId().equals(group.getId())).findFirst().get();
-		} catch (NoSuchElementException e) {
-			throw new InexistentTacsModelException("get failed");
-		}
+		for (CharacterGroup _group : groupList)
+			if (_group.sameModels(group))
+				return _group;
+		throw new InexistentTacsModelException("get failed");
 	}
 
 	@Override

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/MarvelCharacterTestRepository.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/MarvelCharacterTestRepository.java
@@ -6,6 +6,7 @@ import java.util.NoSuchElementException;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.models.TacsModel;
 import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
 
 public class MarvelCharacterTestRepository implements MarvelCharacterDAO {
@@ -36,12 +37,11 @@ public class MarvelCharacterTestRepository implements MarvelCharacterDAO {
 	}
 
 	@Override
-	public MarvelCharacter get(MarvelCharacter _character) throws InexistentTacsModelException {
-		try {
-			return characters.stream().filter(o -> o.getId().equals(_character.getId())).findFirst().get();
-		} catch (NoSuchElementException e) {
-			throw new InexistentTacsModelException("get failed");
-		}
+	public MarvelCharacter get(TacsModel _character) throws InexistentTacsModelException {
+		for (MarvelCharacter character : characters)
+			if (character.sameModels(_character))
+				return character;
+		throw new InexistentTacsModelException("get failed");
 	}
 
 }

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/MarvelCharacterTestRepository.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/MarvelCharacterTestRepository.java
@@ -2,7 +2,6 @@ package com.utn.tacs.tacsthree.persistence.mocks;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
 import com.utn.tacs.tacsthree.models.MarvelCharacter;

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/UserTestRepository.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/UserTestRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
+import com.utn.tacs.tacsthree.models.MarvelCharacter;
 import com.utn.tacs.tacsthree.models.User;
 import com.utn.tacs.tacsthree.persistence.UserDAO;
 
@@ -38,11 +39,10 @@ public class UserTestRepository implements UserDAO {
 
 	@Override
 	public User get(User user) throws InexistentTacsModelException {
-		try {
-			return userList.stream().filter(o -> o.getId().equals(user.getId())).findFirst().get();
-		} catch (NoSuchElementException e) {
-			throw new InexistentTacsModelException("get failed");
-		}
+		for (User _user : userList)
+			if (_user.sameModels(user))
+				return _user;
+		throw new InexistentTacsModelException("get failed");
 	}
 
 	@Override

--- a/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/UserTestRepository.java
+++ b/src/main/java/com/utn/tacs/tacsthree/persistence/mocks/UserTestRepository.java
@@ -2,10 +2,8 @@ package com.utn.tacs.tacsthree.persistence.mocks;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
-import com.utn.tacs.tacsthree.models.MarvelCharacter;
 import com.utn.tacs.tacsthree.models.User;
 import com.utn.tacs.tacsthree.persistence.UserDAO;
 

--- a/src/test/java/com/utn/tacs/tacsthree/api/v1/controllers/CharacterGroupsControllerTest.java
+++ b/src/test/java/com/utn/tacs/tacsthree/api/v1/controllers/CharacterGroupsControllerTest.java
@@ -1,0 +1,157 @@
+package com.utn.tacs.tacsthree.api.v1.controllers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.utn.tacs.tacsthree.exceptions.InexistentTacsModelException;
+import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
+import com.utn.tacs.tacsthree.models.CharacterGroup;
+import com.utn.tacs.tacsthree.models.MarvelCharacter;
+import com.utn.tacs.tacsthree.persistence.CharacterGroupDAO;
+import com.utn.tacs.tacsthree.persistence.MarvelCharacterDAO;
+import com.utn.tacs.tacsthree.persistence.mocks.CharacterGroupTestRepository;
+import com.utn.tacs.tacsthree.persistence.mocks.MarvelCharacterTestRepository;
+
+public class CharacterGroupsControllerTest {
+
+	private CharacterGroupsController controller;
+	private CharacterGroupDAO groupRepo = CharacterGroupTestRepository.getInstance();
+	private MarvelCharacterDAO characRepo = MarvelCharacterTestRepository.getInstance();
+
+	@Before
+	public void setUp() {
+		((CharacterGroupTestRepository) groupRepo).restart();
+		((MarvelCharacterTestRepository) characRepo).restart();
+		controller = new CharacterGroupsController(groupRepo, characRepo);
+	}
+
+	@Test
+	public void testGetAllGroups() {
+		assertEquals(((CharacterGroupTestRepository) groupRepo).groupList.size(), controller.getAllGroups().size());
+	}
+
+	@Test
+	public void getGroupCorrectly() {
+		CharacterGroup _group = controller.getGroup("0709b8799a96331925075510");
+		assertNotEquals(null, _group.getName());
+		assertNotEquals(null, _group.getId());
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void getInexistentGroup() {
+		controller.getGroup("0709b8799a96331925075511");
+	}
+
+	@Test
+	public void createValidGroup() {
+		Integer groups_amount = ((CharacterGroupTestRepository) groupRepo).groupList.size();
+		CharacterGroup group = new CharacterGroup("0709b8799a96331925075511");
+		group.setName("Tester");
+		group.addCharacters(characRepo.get().get(0));
+		controller.createGroup(group);
+		assertEquals(groups_amount + 1, ((CharacterGroupTestRepository) groupRepo).groupList.size(), 0);
+	}
+
+	@Test(expected = InvalidTacsModelException.class)
+	public void createInvalidGroupNullName() {
+		controller.createGroup(new CharacterGroup("0709b8799a96331925075511"));
+	}
+
+	@Test(expected = InvalidTacsModelException.class)
+	public void createInvalidGroupEmptyCharacters() {
+		CharacterGroup group = new CharacterGroup("0709b8799a96331925075511");
+		group.setName("Tester");
+		controller.createGroup(group);
+	}
+
+	@Test
+	public void updateValidGroup() {
+		CharacterGroup group = controller.getGroup("0709b8799a96331925075510");
+		group.setName("Group with different name");
+		CharacterGroup updateResult = controller.updateGroup(group);
+		assertEquals("Group with different name", updateResult.getName());
+	}
+
+	@Test(expected = InvalidTacsModelException.class)
+	public void updateInvalidGroupNullName() {
+		controller.updateGroup(new CharacterGroup("0709b8799a96331925075510"));
+	}
+
+	@Test(expected = InvalidTacsModelException.class)
+	public void updateInvalidGroupEmptyCharacters() {
+		CharacterGroup group = new CharacterGroup("0709b8799a96331925075510");
+		group.setName("Tester");
+		controller.createGroup(group);
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void updateInexistentGroup() {
+		CharacterGroup group = new CharacterGroup("123ab8799a96331925075301");
+		group.setName("Tester");
+		group.addCharacters(characRepo.get().get(1));
+		controller.updateGroup(group);
+	}
+
+	@Test
+	public void deleteGroup() {
+		controller.getGroup("0709b8799a96331925075510");
+		controller.deleteGroup("0709b8799a96331925075510");
+		try {
+			controller.getGroup("5709b8799a96331925075301");
+		} catch (InexistentTacsModelException e) {
+			assertEquals("get failed", e.getMessage());
+		}
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void deleteInexistentGroup() {
+		controller.deleteGroup("123ab8799a96331925075301");
+	}
+
+	@Test
+	public void getCharactersOfGroup() {
+		assertEquals(controller.getGroup("0709b8799a96331925075510").getCharacters().size(),
+				controller.getCharacters("0709b8799a96331925075510").size());
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void getCharacterOfInvalidGroup() {
+		controller.getCharacters("123ab1111a96331925075301");
+	}
+
+	@Test
+	public void addCharacterOfGroup() {
+		controller.addCharacter("0709b8799a96331925075510", characRepo.get().get(1));
+		assertEquals(2, controller.getGroup("0709b8799a96331925075510").getCharacters().size());
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void addCharacterToInexistentGroup() {
+		controller.addCharacter("123ab8788a96331925075301", characRepo.get().get(1));
+	}
+
+	@Test(expected = InvalidTacsModelException.class)
+	public void addInvalidCharacterToGroup() {
+		controller.addCharacter("0709b8799a96331925075510", new MarvelCharacter());
+	}
+
+	@Test
+	public void removeCharacterFromGroup() {
+		controller.addCharacter("0709b8799a96331925075510", characRepo.get().get(1));
+		assertEquals(2, controller.getGroup("0709b8799a96331925075510").getCharacters().size());
+		controller.removeCharacter("0709b8799a96331925075510", characRepo.get().get(1).getId());
+		assertEquals(1, controller.getGroup("0709b8799a96331925075510").getCharacters().size());
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void removeInexistentCharacterOfGroup() {
+		controller.removeCharacter("0709b8799a96331925075510", "123ab1111a96331925075302");
+	}
+
+	@Test(expected = InexistentTacsModelException.class)
+	public void removeInexistentCharacterOfUser() {
+		controller.removeCharacter("5709b8799a96331925075301", characRepo.get().get(1).getId());
+	}
+}

--- a/src/test/java/com/utn/tacs/tacsthree/api/v1/controllers/CommonControllerTest.java
+++ b/src/test/java/com/utn/tacs/tacsthree/api/v1/controllers/CommonControllerTest.java
@@ -1,5 +1,0 @@
-package com.utn.tacs.tacsthree.api.v1.controllers;
-
-public class CommonControllerTest {
-
-}

--- a/src/test/java/com/utn/tacs/tacsthree/api/v1/controllers/UsersControllerTest.java
+++ b/src/test/java/com/utn/tacs/tacsthree/api/v1/controllers/UsersControllerTest.java
@@ -91,69 +91,68 @@ public class UsersControllerTest {
 	}
 
 	@Test
-	public void getFavoriteOfUser() {
+	public void getCharacterOfUser() {
 		User _user = new User("5709b8799a96331925075301", "Tom2");
-		_user.addFavorite(new MarvelCharacter("5709b8799a96331925075301", "Test", "Hey Baby!"));
+		_user.addCharacter(new MarvelCharacter("5709b8799a96331925075301", "Test", "Hey Baby!"));
 		controller.updateUser(_user);
-		assertEquals(1, controller.getFavoritesOf("5709b8799a96331925075301").size());
+		assertEquals(1, controller.getCharactersOf("5709b8799a96331925075301").size());
 	}
 
 	@Test(expected = InexistentTacsModelException.class)
-	public void getFavoriteOfInvalidUser() {
-		controller.getFavoritesOf("123ab1111a96331925075301");
+	public void getCharacterOfInvalidUser() {
+		controller.getCharactersOf("123ab1111a96331925075301");
 	}
 
 	@Test
-	public void addFavoriteOfUser() {
-		controller.addFavorite("5709b8799a96331925075301",
+	public void addCharacterOfUser() {
+		controller.addCharacter("5709b8799a96331925075301",
 				new MarvelCharacter("1309b8799a96331925075301", "Test", "Hey Baby!"));
-		assertEquals(1, controller.getUser("5709b8799a96331925075301").getFavorites().size());
+		assertEquals(1, controller.getUser("5709b8799a96331925075301").getCharacters().size());
 	}
 
 	@Test(expected = InexistentTacsModelException.class)
-	public void addFavoriteOfInexistentUser() {
-		controller.addFavorite("123ab8788a96331925075301",
+	public void addCharacterOfInexistentUser() {
+		controller.addCharacter("123ab8788a96331925075301",
 				new MarvelCharacter("123ab1111a96331925075301", "Test", "Hey Baby!"));
 	}
 
 	@Test(expected = InvalidTacsModelException.class)
-	public void addFavoriteOfInvalidUser() {
-		controller.addFavorite("5709b8799a96331925075301", new MarvelCharacter());
+	public void addCharacterOfInvalidUser() {
+		controller.addCharacter("5709b8799a96331925075301", new MarvelCharacter());
 	}
 
 	@Test
-	public void removeFavoritesOfUser() {
-		controller.addFavorite("5709b8799a96331925075301",
+	public void removeCharactersOfUser() {
+		controller.addCharacter("5709b8799a96331925075301",
 				new MarvelCharacter("1309b8799a96331925075301", "Test", "Hey Baby!"));
-		controller.addFavorite("5709b8799a96331925075301",
+		controller.addCharacter("5709b8799a96331925075301",
 				new MarvelCharacter("1309b8799a96331925075302", "Test2", "Hey Baby!"));
-		assertEquals(2, controller.getUser("5709b8799a96331925075301").getFavorites().size());
-		controller.removeFavorites("5709b8799a96331925075301");
-		assertEquals(0, controller.getUser("5709b8799a96331925075301").getFavorites().size());
+		assertEquals(2, controller.getUser("5709b8799a96331925075301").getCharacters().size());
+		controller.removeCharactersOf("5709b8799a96331925075301");
+		assertEquals(0, controller.getUser("5709b8799a96331925075301").getCharacters().size());
 	}
 
 	@Test(expected = InexistentTacsModelException.class)
 	public void removeFavoritesOfInexistentUser() {
-		controller.removeFavorites("123ab8788a96331925075301");
+		controller.removeCharactersOf("123ab8788a96331925075301");
 	}
 
 	@Test
-	public void removeFavoriteOfUser() {
-		characRepo.get();
-		controller.addFavorite("5709b8799a96331925075301", characRepo.get().get(0));
-		controller.addFavorite("5709b8799a96331925075301", characRepo.get().get(1));
-		assertEquals(2, controller.getUser("5709b8799a96331925075301").getFavorites().size());
-		controller.removeFavorite("5709b8799a96331925075301", characRepo.get().get(0).getId());
-		assertEquals(1, controller.getUser("5709b8799a96331925075301").getFavorites().size());
+	public void removeCharacterOfUser() {
+		controller.addCharacter("5709b8799a96331925075301", characRepo.get().get(0));
+		controller.addCharacter("5709b8799a96331925075301", characRepo.get().get(1));
+		assertEquals(2, controller.getUser("5709b8799a96331925075301").getCharacters().size());
+		controller.removeCharacter("5709b8799a96331925075301", characRepo.get().get(0).getId());
+		assertEquals(1, controller.getUser("5709b8799a96331925075301").getCharacters().size());
 	}
 
 	@Test(expected = InexistentTacsModelException.class)
-	public void removeFavoriteOfInexistentUser() {
-		controller.removeFavorite("123ab1111a96331925075302", "123ab1111a96331925075302");
+	public void removeCharacterOfInexistentUser() {
+		controller.removeCharacter("123ab1111a96331925075302", "123ab1111a96331925075302");
 	}
 
 	@Test(expected = InexistentTacsModelException.class)
-	public void removeInexistentFavoriteOfUser() {
-		controller.removeFavorite("5709b8799a96331925075301", "123ab1111a96331925075302");
+	public void removeInexistentCharacterOfUser() {
+		controller.removeCharacter("5709b8799a96331925075301", "123ab1111a96331925075302");
 	}
 }

--- a/src/test/java/com/utn/tacs/tacsthree/models/MarvelCharacterTest.java
+++ b/src/test/java/com/utn/tacs/tacsthree/models/MarvelCharacterTest.java
@@ -10,14 +10,14 @@ public class MarvelCharacterTest {
 
 	@Test
 	public void createCharacterRequiredValues() {
-		MarvelCharacter testSpidey = new MarvelCharacter();
+		TacsModel testSpidey = new MarvelCharacter();
 		testSpidey.setId("5709b8799a96331925075306");
 		testSpidey.valid();
 	}
 
 	@Test
 	public void createCharacterWithoutId() {
-		MarvelCharacter testSpidey = new MarvelCharacter();
+		TacsModel testSpidey = new MarvelCharacter();
 		try {
 			testSpidey.valid();
 		} catch (InvalidTacsModelException e) {

--- a/src/test/java/com/utn/tacs/tacsthree/models/ReportTest.java
+++ b/src/test/java/com/utn/tacs/tacsthree/models/ReportTest.java
@@ -1,0 +1,26 @@
+package com.utn.tacs.tacsthree.models;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.utn.tacs.tacsthree.exceptions.InvalidTacsModelException;
+
+public class ReportTest {
+
+	@Test
+	public void createReportRequiredValues() {
+		Report report = new ReportFavoriteCharacterRanking();
+		report.setId("5709b8799a96331925075306");
+		report.valid();
+	}
+
+	@Test
+	public void createReportWithoutId() {
+		Report report = new ReportFavoriteCharacterRanking();
+		try {
+			report.valid();
+		} catch (InvalidTacsModelException e) {
+			assertEquals("invalid id", e.getMessage());
+		}
+	}
+}

--- a/src/test/java/com/utn/tacs/tacsthree/persistence/mongo/UserMongoMorphiaTest.java
+++ b/src/test/java/com/utn/tacs/tacsthree/persistence/mongo/UserMongoMorphiaTest.java
@@ -50,7 +50,7 @@ public class UserMongoMorphiaTest {
 		User persistedUser = datastore.get(testSubject);
 		assertEquals("Id isn't same", testSubject.getId(), persistedUser.getId());
 		assertEquals("Name isn't same", testSubject.getName(), persistedUser.getName());
-		assertEquals("Favourites size isn't same", testSubject.getFavorites().size(),
-				persistedUser.getFavorites().size());
+		assertEquals("Favourites size isn't same", testSubject.getCharacters().size(),
+				persistedUser.getCharacters().size());
 	}
 }


### PR DESCRIPTION
Tiro un par de fixes respecto a las observaciones de la entrega 1 que nos hizo Marto:

* Faltaban los reportes, tanto ruta, modelo y controller. Por ahora está, pero falta hacer el backend que corresponde bien haciendo el trabajo que deberia dicho reporte (ranking de personajes faveados).
* Le agregue dependencia de los grupos a los usuarios, pero falta modificar los controllers para que hagan uso del mismo. Falta la annotation de morfia de `@Reference` para que referencie el grupo y no lo copie al pedo xq nos puede genera inconsistencia en lo datos. Esa misma annotation hay que usar para los personajes.
* Saqué casi todas las cosas que eran muy java8 exclusive, pero falta cambiar el pom.xml y adaptar lo que está en la carpeta openshift como para poder tirarlo ahí y que haga magia solo.
* Algunos cuantos fixes de cosilas que encontré por ahi.